### PR TITLE
Update ImmersiveEngineering.zs

### DIFF
--- a/scripts/ImmersiveEngineering.zs
+++ b/scripts/ImmersiveEngineering.zs
@@ -51,34 +51,32 @@ mods.immersiveengineering.MetalPress.addRecipe(<Railcraft:part.plate:2>, <ore:in
 */
 
 #changed 2 ingots shaped for 4 iron bars to 2 iron bars
+
 recipes.removeShaped(<ImmersiveEngineering:material:14>);
-recipes.addShaped(<ImmersiveEngineering:material:14> * 2, 	[[	<ore:ingotIron>,null,null],
-															[	<ore:ingotIron>,null,null],
-															[	null,			null,null]]);
+recipes.addShaped(<ImmersiveEngineering:material:14> * 2, 	[[	<ore:ingotIron>,		null,null],
+								[	<ore:ingotIron>,		null,null],
+								[	null,				null,null]]);
 
 #changed 2 ingots shaped for 4 steel bars to 2 steel bars
+
 recipes.removeShaped(<ImmersiveEngineering:material:15>);
-recipes.addShaped(<ImmersiveEngineering:material:15> * 2, 	[[	<ore:ingotSteel>,null,null],
-															[	<ore:ingotSteel>,null,null],
-															[	null,			null,null]]);
+recipes.addShaped(<ImmersiveEngineering:material:15> * 2, 	[[	<ore:ingotSteel>,		null,null],
+								[	<ore:ingotSteel>,		null,null],
+								[	null,				null,null]]);
 															
 #changed 2 ingots shaped for 4 aluminum bars to 2 aluminum bars
+
 recipes.removeShaped(<ImmersiveEngineering:material:16>);
-recipes.addShaped(<ImmersiveEngineering:material:16> * 2, 	[[	<ore:ingotAluminum>,null,null],
-															[	<ore:ingotAluminum>,null,null],
-															[	null,			null,null]]);
-															
-#changed 2 ingots shaped for 4 steel bars to 2 steel bars
-recipes.removeShaped(<ImmersiveEngineering:material:15>);
-recipes.addShaped(<ImmersiveEngineering:material:15> * 2, 	[[	<ore:ingotSteel>,null,null],
-															[	<ore:ingotSteel>,null,null],
-															[	null,			null,null]]);
+recipes.addShaped(<ImmersiveEngineering:material:16> * 2, 	[[	<ore:ingotAluminum>,		null,null],
+								[	<ore:ingotAluminum>,		null,null],
+								[	null,				null,null]]);
+
 
 # Lapis produces sapphire dust in the crusher
 mods.immersiveengineering.Crusher.removeRecipe(<ElectriCraft:electricraft_item_crafting>);
 mods.immersiveengineering.Crusher.addRecipe(<PracticalLogistics:SapphireDust>, <minecraft:dye:4>, 1600, null, 0.0);
 
-# Blast furnace produce 1 ore per 4 raw ores
+# Blast furnace produces 1 ore per 4 raw ores
 mods.immersiveengineering.BlastFurnace.addRecipe(<minecraft:iron_ore>,<HarderOres:ore_chunk:8> * 8, 1200, <minecraft:cobblestone>);
 mods.immersiveengineering.BlastFurnace.addRecipe(<minecraft:gold_ore>,<HarderOres:ore_chunk:9> * 8, 1200, <minecraft:cobblestone>);
 mods.immersiveengineering.BlastFurnace.addRecipe(<ElectriCraft:electricraft_block_ore:1>,<HarderOres:ore_chunk:12> * 8, 1200, <minecraft:cobblestone>);


### PR DESCRIPTION
Changes the hand craft expense for * bars from Immersive Engineering to be more expensive than using the Metal Press by a factor of 2 (I reduced the yield of hand crafting as requested by Haggle1996)